### PR TITLE
Fix OpenCL test failures on Solaris.

### DIFF
--- a/make/config/cl-impl.cfg
+++ b/make/config/cl-impl.cfg
@@ -3,7 +3,6 @@ Include cl-common.cfg
 Style ImplOnly
 
 #imports for all generated java files
-Import com.jogamp.opencl.llb.*
 Import com.jogamp.opencl.llb.gl.CLGL
 Import java.security.AccessController
 Import java.security.PrivilegedAction

--- a/make/config/clImplCustomCode.java
+++ b/make/config/clImplCustomCode.java
@@ -1,30 +1,33 @@
 
+    /** If null, OpenCL is not available on this machine. */
     static final DynamicLibraryBundle dynamicLookupHelper;
     protected static final CLProcAddressTable addressTable;
 
     static {
-      addressTable = new CLProcAddressTable();
-      if(null==addressTable) {
-        throw new RuntimeException("Couldn't instantiate ALProcAddressTable");
-      }
-  
-      dynamicLookupHelper = AccessController.doPrivileged(new PrivilegedAction<DynamicLibraryBundle>() {
+        addressTable = new CLProcAddressTable();
+        dynamicLookupHelper = AccessController.doPrivileged(new PrivilegedAction<DynamicLibraryBundle>() {
                                   public DynamicLibraryBundle run() {
-                                      final DynamicLibraryBundle bundle =  new DynamicLibraryBundle(new CLDynamicLibraryBundleInfo());
-                                      if(null==bundle) {
-                                        throw new RuntimeException("Null CLDynamicLookupHelper");
-                                      }
+                                      final DynamicLibraryBundle bundle = new DynamicLibraryBundle(new CLDynamicLibraryBundleInfo());
                                       if(!bundle.isToolLibLoaded()) {
-                                        throw new RuntimeException("Couln't load native CL library");
+                                          // couldn't load native CL library
+                                          // TODO: log this?
+                                          return null;
                                       }
                                       if(!bundle.isLibComplete()) {
-                                        throw new RuntimeException("Couln't load native CL/JNI glue library");
+                                          // couldn't load native CL/JNI glue library
+                                          // TODO: log this?
+                                          return null;
                                       }
                                       addressTable.reset(bundle);
                                       return bundle;
                                   } } );
     }
 
+    /**
+     * Accessor.
+     * @returns true if OpenCL is available on this machine.
+     */
+    public static boolean isAvailable() { return dynamicLookupHelper != null; }
     public static CLProcAddressTable getCLProcAddressTable() { return addressTable; }
 
     static long clGetExtensionFunctionAddress(long clGetExtensionFunctionAddressHandle, java.lang.String procname)

--- a/test/com/jogamp/opencl/CLBufferTest.java
+++ b/test/com/jogamp/opencl/CLBufferTest.java
@@ -30,6 +30,7 @@ package com.jogamp.opencl;
 
 import com.jogamp.opencl.CLMemory.Mem;
 import com.jogamp.opencl.CLMemory.Map;
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 import com.jogamp.common.nio.Buffers;
 
@@ -66,6 +67,8 @@ public class CLBufferTest extends UITestCase {
     public void createBufferTest() {
 
         out.println(" - - - highLevelTest; create buffer test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
         try{
@@ -121,6 +124,8 @@ public class CLBufferTest extends UITestCase {
     public void writeCopyReadBufferTest() {
 
         out.println(" - - - highLevelTest; copy buffer test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         final int elements = NUM_ELEMENTS;
 
@@ -153,6 +158,8 @@ public class CLBufferTest extends UITestCase {
     public void bufferWithHostPointerTest() {
 
         out.println(" - - - highLevelTest; host pointer test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         final int elements = NUM_ELEMENTS;
 
@@ -197,6 +204,8 @@ public class CLBufferTest extends UITestCase {
     public void mapBufferTest() {
 
         out.println(" - - - highLevelTest; map buffer test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         final int elements = NUM_ELEMENTS;
         final int sizeInBytes = elements*SIZEOF_INT;
@@ -250,6 +259,8 @@ public class CLBufferTest extends UITestCase {
     public void subBufferTest() {
 
         out.println(" - - - subBufferTest - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform platform = CLPlatform.getDefault(version(CL_1_1));
         if(platform == null) {
@@ -313,6 +324,8 @@ public class CLBufferTest extends UITestCase {
     public void destructorCallbackTest() throws InterruptedException {
 
         out.println(" - - - destructorCallbackTest - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform platform = CLPlatform.getDefault(version(CL_1_1));
         if(platform == null) {

--- a/test/com/jogamp/opencl/CLCommandQueueTest.java
+++ b/test/com/jogamp/opencl/CLCommandQueueTest.java
@@ -35,6 +35,7 @@ import org.junit.runners.MethodSorters;
 
 import java.util.concurrent.CountDownLatch;
 
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 import com.jogamp.opencl.util.MultiQueueBarrier;
 import com.jogamp.opencl.CLCommandQueue.Mode;
@@ -101,6 +102,8 @@ public class CLCommandQueueTest extends UITestCase {
     public void eventsTest() throws IOException {
 
         out.println(" - - - event synchronization test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
 
@@ -171,6 +174,8 @@ public class CLCommandQueueTest extends UITestCase {
     public void eventConditionsTest() throws IOException {
 
         out.println(" - - - event conditions test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform platform = CLPlatform.getDefault(CLPlatformFilters.queueMode(OUT_OF_ORDER_MODE));
 
@@ -231,6 +236,8 @@ public class CLCommandQueueTest extends UITestCase {
     public void profilingEventsTest() throws IOException {
 
         out.println(" - - - event synchronization test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
 
@@ -286,6 +293,8 @@ public class CLCommandQueueTest extends UITestCase {
     @Test
     public void customEventsTest() throws IOException, InterruptedException {
         out.println(" - - - user events test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform[] platforms = CLPlatform.listCLPlatforms();
         CLPlatform theChosenOne = platforms[0];
@@ -362,6 +371,8 @@ public class CLCommandQueueTest extends UITestCase {
     public void eventCallbackTest() throws InterruptedException {
 
         out.println(" - - - event callback test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform platform = CLPlatform.getDefault();
 
@@ -402,6 +413,8 @@ public class CLCommandQueueTest extends UITestCase {
     public void concurrencyTest() throws IOException, InterruptedException {
 
         out.println(" - - - QueueBarrier test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         final int elements = ONE_MB / SIZEOF_INT * 10; // 20MB per buffer
 

--- a/test/com/jogamp/opencl/CLImageTest.java
+++ b/test/com/jogamp/opencl/CLImageTest.java
@@ -40,6 +40,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 
 import static org.junit.Assert.*;
@@ -83,6 +84,9 @@ public class CLImageTest extends UITestCase {
 
     @Test
     public void supportedImageFormatsTest() {
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
+
         CLDevice device = getCompatibleDevice();
         if(device == null) {
             out.println("WARNING: can not test image api.");
@@ -105,6 +109,9 @@ public class CLImageTest extends UITestCase {
 
     @Test
     public void image2dCopyTest() throws IOException {
+
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLDevice device = getCompatibleDevice();
         if(device == null) {
@@ -141,6 +148,9 @@ public class CLImageTest extends UITestCase {
 
     @Test
     public void image2dKernelCopyTest() throws IOException {
+
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLDevice device = getCompatibleDevice();
         if(device == null) {

--- a/test/com/jogamp/opencl/CLProgramTest.java
+++ b/test/com/jogamp/opencl/CLProgramTest.java
@@ -28,6 +28,7 @@
 
 package com.jogamp.opencl;
 
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 import com.jogamp.opencl.util.CLBuildConfiguration;
 import com.jogamp.opencl.util.CLProgramConfiguration;
@@ -78,6 +79,8 @@ public class CLProgramTest extends UITestCase {
     public void rebuildProgramTest() throws IOException {
 
         out.println(" - - - CLProgramTest; rebuild program test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
         CLProgram program = context.createProgram(getClass().getResourceAsStream("testkernels.cl"));
@@ -117,6 +120,8 @@ public class CLProgramTest extends UITestCase {
     public void programBinariesTest() throws IOException {
 
         out.println(" - - - CLProgramTest; down-/upload binaries test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
         CLProgram program = context.createProgram(getClass().getResourceAsStream("testkernels.cl"))
@@ -194,6 +199,8 @@ public class CLProgramTest extends UITestCase {
     @Test
     public void builderTest() throws IOException, ClassNotFoundException, InterruptedException {
         out.println(" - - - CLProgramTest; program builder test - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLContext context = CLContext.create();
         CLProgram program = context.createProgram(getClass().getResourceAsStream("testkernels.cl"));
@@ -276,6 +283,9 @@ public class CLProgramTest extends UITestCase {
     @Test
     public void kernelTest() {
 
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
+
         String source = "__attribute__((reqd_work_group_size(1, 1, 1))) kernel void foo(float a, int b, short c) { }\n";
 
         CLContext context = CLContext.create();
@@ -323,6 +333,9 @@ public class CLProgramTest extends UITestCase {
 
     @Test
     public void createAllKernelsTest() {
+
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         String source = "kernel void foo(int a) { }\n"+
                         "kernel void bar(float b) { }\n";

--- a/test/com/jogamp/opencl/HighLevelBindingTest.java
+++ b/test/com/jogamp/opencl/HighLevelBindingTest.java
@@ -40,6 +40,7 @@ import com.jogamp.opencl.CLDevice.LocalMemType;
 import com.jogamp.opencl.CLDevice.Type;
 import com.jogamp.opencl.CLDevice.Capabilities;
 import com.jogamp.opencl.llb.CL;
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 
 import java.io.IOException;
@@ -137,6 +138,8 @@ public class HighLevelBindingTest extends UITestCase {
     public void contextlessTest() {
 
         out.println(" - - - highLevelTest; contextless - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         // platform/device info tests
         CLPlatform[] clPlatforms = CLPlatform.listCLPlatforms();
@@ -205,6 +208,9 @@ public class HighLevelBindingTest extends UITestCase {
     @Test
     public void platformTest() {
 
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
+
         CLPlatform platformGPU = CLPlatform.getDefault(version(CL_1_0), type(GPU));
         CLPlatform platformCPU = CLPlatform.getDefault(version(CL_1_0), type(CPU));
 
@@ -221,6 +227,8 @@ public class HighLevelBindingTest extends UITestCase {
     public void createContextTest() {
 
         out.println(" - - - highLevelTest; create context - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform platform = CLPlatform.getDefault();
         CLDevice[] devices = platform.listCLDevices();
@@ -280,6 +288,8 @@ public class HighLevelBindingTest extends UITestCase {
     public void vectorAddGMTest() throws IOException {
 
         out.println(" - - - highLevelTest; global memory kernel - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLPlatform[] clPlatforms = CLPlatform.listCLPlatforms();
         CLContext context = CLContext.create(clPlatforms[0]);

--- a/test/com/jogamp/opencl/LowLevelBindingTest.java
+++ b/test/com/jogamp/opencl/LowLevelBindingTest.java
@@ -33,6 +33,7 @@ import java.util.Random;
 import com.jogamp.common.nio.PointerBuffer;
 import com.jogamp.opencl.llb.impl.BuildProgramCallback;
 import com.jogamp.opencl.llb.CL;
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 
 import java.io.IOException;
@@ -102,6 +103,8 @@ public class LowLevelBindingTest extends UITestCase {
     public void contextlessTest() {
 
         out.println(" - - - lowLevelTest; contextless binding - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CL cl = CLPlatform.getLowLevelCLInterface();
 
@@ -174,6 +177,8 @@ public class LowLevelBindingTest extends UITestCase {
     public void createContextTest() {
 
         out.println(" - - - createContextTest - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CL cl = CLPlatform.getLowLevelCLInterface();
 
@@ -219,6 +224,8 @@ public class LowLevelBindingTest extends UITestCase {
     public void lowLevelVectorAddTest() throws InterruptedException {
 
         out.println(" - - - lowLevelTest2; VectorAdd kernel - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CL cl = CLPlatform.getLowLevelCLInterface();
 

--- a/test/com/jogamp/opencl/gl/CLGLTest.java
+++ b/test/com/jogamp/opencl/gl/CLGLTest.java
@@ -45,6 +45,7 @@ import com.jogamp.newt.opengl.GLWindow;
 import com.jogamp.opencl.CLContext;
 import com.jogamp.opencl.CLMemory.Mem;
 import com.jogamp.opencl.CLPlatform;
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 import com.jogamp.opencl.util.CLDeviceFilters;
 import com.jogamp.opencl.util.CLPlatformFilters;
@@ -106,9 +107,11 @@ public class CLGLTest extends UITestCase {
     @Test(timeout=15000)
     public void createContextTest() {
 
-        initGL();
-
         out.println(" - - - glcl; createContextTest - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
+
+        initGL();
 
         CLPlatform platform = CLPlatform.getDefault(CLPlatformFilters.glSharing());
         CLDevice device = platform.getMaxFlopsDevice(CLDeviceFilters.glSharing());
@@ -149,6 +152,8 @@ public class CLGLTest extends UITestCase {
     public void vboSharing() {
 
         out.println(" - - - glcl; vboSharing - - - ");
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         initGL();
         makeGLCurrent();

--- a/test/com/jogamp/opencl/test/util/MiscUtils.java
+++ b/test/com/jogamp/opencl/test/util/MiscUtils.java
@@ -31,6 +31,8 @@ package com.jogamp.opencl.test.util;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import com.jogamp.opencl.llb.impl.CLAbstractImpl;
+
 import static java.lang.System.*;
 import static org.junit.Assert.*;
 
@@ -76,5 +78,18 @@ public class MiscUtils {
         }
         a.rewind();
         b.rewind();
+    }
+
+    /**
+     * @return true if OpenCL is not available for this operating system, CPU architecture, et cetera.
+     * This is meant to be a check that there can't possibly be a driver installed because
+     * nobody makes one, not just a check that we didn't see one.
+     */
+    public static final boolean isOpenCLUnavailable() {
+        if(!CLAbstractImpl.isAvailable() && System.getProperty("os.name").startsWith("SunOS")) {
+            out.println("OpenCL not available on this operating system. Skipping test.");
+            return true;
+        }
+        return false;
     }
 }

--- a/test/com/jogamp/opencl/util/concurrent/CLMultiContextTest.java
+++ b/test/com/jogamp/opencl/util/concurrent/CLMultiContextTest.java
@@ -10,6 +10,7 @@ import com.jogamp.opencl.CLContext;
 import com.jogamp.opencl.CLDevice;
 import com.jogamp.opencl.CLKernel;
 import com.jogamp.opencl.CLPlatform;
+import com.jogamp.opencl.test.util.MiscUtils;
 import com.jogamp.opencl.test.util.UITestCase;
 import com.jogamp.opencl.util.concurrent.CLQueueContext.CLSimpleQueueContext;
 import com.jogamp.opencl.util.concurrent.CLQueueContextFactory.CLSimpleContextFactory;
@@ -47,6 +48,9 @@ public class CLMultiContextTest extends UITestCase {
 
     @Test
     public void createMultiContextTest() {
+
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLMultiContext mc = CLMultiContext.create(CLPlatform.listCLPlatforms());
 
@@ -116,6 +120,9 @@ public class CLMultiContextTest extends UITestCase {
 
     @Test
     public void commandQueuePoolTest() throws InterruptedException, ExecutionException {
+
+        if(MiscUtils.isOpenCLUnavailable())
+            return;
 
         CLMultiContext mc = CLMultiContext.create(CLPlatform.listCLPlatforms());
 


### PR DESCRIPTION
Since nobody currently makes an OpenCL driver for Solaris, all the
tests used to fail, which told us nothing. This commit adds code
to check whether OpenCL is unavailable and the OS is Solaris, in
which case the test contents are skipped. If an OpenCL driver ever
appears for Solaris, or if we start testing on another platform
with no OpenCL driver, there's now one single place to add or remove
checks that will allow for this.
